### PR TITLE
OS-specific stubs to fix compilation on Mac OS X

### DIFF
--- a/src/source.rs
+++ b/src/source.rs
@@ -23,21 +23,38 @@ impl Source for RealTime {
 }
 
 use libc;
+
+#[cfg(target_os = "linux")]
 fn clock_gettime(clock: libc::c_int) -> Result<libc::timespec, ()> {
     let mut tp: libc::timespec = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,
     };
 
-    let ret = unsafe {
-        libc::clock_gettime(clock, &mut tp)
+    let ret = unsafe { libc::clock_gettime(clock, &mut tp) };
+
+    if ret == 0 { Ok(tp) } else { Err(()) }
+}
+
+#[cfg(target_os = "macos")]
+fn clock_gettime(clock: libc::c_int) -> Result<libc::timespec, ()> {
+    let mut tp: libc::timespec = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
     };
 
-    if ret == 0 {
-        Ok(tp)
-    } else {
-        Err(())
-    }
+    //let tb = libc::mach_timebase_info_data_t {
+    //    numer: 0,
+    //    denom: 0,
+    //};
+
+    //let ret = unsafe {
+    //    libc::mach_timebase_info(&tb);
+    //    libc::mach_absolute_time()
+    //};
+
+    //if ret == 0 { Ok(tp) } else { Err(()) }
+    Ok(tp)
 }
 
 #[derive(Default)]

--- a/src/source.rs
+++ b/src/source.rs
@@ -60,8 +60,15 @@ fn clock_gettime(clock: libc::c_int) -> Result<libc::timespec, ()> {
 #[derive(Default)]
 pub struct ProcessTime;
 impl Source for ProcessTime {
+    #[cfg(target_os = "linux")]
     fn get_time(&self) -> u64 {
         let time = clock_gettime(libc::CLOCK_PROCESS_CPUTIME_ID).unwrap();
+        (time.tv_sec as u64) * 1000_000_000 + (time.tv_nsec as u64)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn get_time(&self) -> u64 {
+        let time = clock_gettime(0).unwrap();
         (time.tv_sec as u64) * 1000_000_000 + (time.tv_nsec as u64)
     }
 }
@@ -69,8 +76,15 @@ impl Source for ProcessTime {
 #[derive(Default)]
 pub struct ThreadTime;
 impl Source for ThreadTime {
+    #[cfg(target_os = "linux")]
     fn get_time(&self) -> u64 {
         let time = clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID).unwrap();
+        (time.tv_sec as u64) * 1000_000_000 + (time.tv_nsec as u64)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn get_time(&self) -> u64 {
+        let time = clock_gettime(0).unwrap();
         (time.tv_sec as u64) * 1000_000_000 + (time.tv_nsec as u64)
     }
 }


### PR DESCRIPTION
Here's my patch that adds a stub that always returns zero when compile on OS X.