### PR TITLE
Use a libc version that has clock_gettime for macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/fintelia/timekeeper"
 license = "MIT/Apache-2.0"
 
 [dependencies]
+libc = ">=0.2.32"
 
 [features]
 default = ["enable_timekeeper"]

--- a/src/source.rs
+++ b/src/source.rs
@@ -23,7 +23,7 @@ impl Source for RealTime {
 }
 
 use libc;
-fn clock_gettime(clock: libc::c_int) -> Result<libc::timespec, ()> {
+fn clock_gettime(clock: libc::clockid_t) -> Result<libc::timespec, ()> {
     let mut tp: libc::timespec = libc::timespec {
         tv_sec: 0,
         tv_nsec: 0,


### PR DESCRIPTION
libc version `0.2.32` [adds support](https://github.com/rust-lang/libc/pull/777) for `clock_gettime` and related functions to macOS, since these were added in macOS version `10.12.6`. This adds an explicit dependency on version `0.2.32` or higher of libc, so that timekeeper builds on macOS as well.

Also changes the type of the `clock` argument given to `clock_gettime` to `clockid_t` - since this can be both an unsigned and a signed int depending on the OS.

Ran the distributary tests with this branch as well, which passed.