### PR TITLE
Add is_running API to check if timer is active

### DIFF
--- a/src/nop_timer.rs
+++ b/src/nop_timer.rs
@@ -20,6 +20,9 @@ impl<T: Tracker, S: Source> Timer<T, S> {
 
     pub fn start(&mut self) {}
     pub fn stop(&mut self) {}
+    pub fn is_running(&self) -> bool {
+        false
+    }
     pub fn get_stats(&self) -> T::Statistics {
         T::Statistics::default()
     }

--- a/src/nop_timerset.rs
+++ b/src/nop_timerset.rs
@@ -23,6 +23,9 @@ impl <Key, T, S> TimerSet<Key, T, S> where Key: Eq + Hash + Clone, T: Tracker, S
 
     pub fn start(&mut self, _: Key) {}
     pub fn stop(&mut self) {}
+    pub fn is_running(&self) -> bool {
+        false
+    }
     pub fn get_stats(&self, _: Key) -> Option<T::Statistics> {
         Some(T::Statistics::default())
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -30,6 +30,11 @@ impl<T: Tracker, S: Source> Timer<T, S> {
         self.tracker.record(time);
     }
 
+    /// Returns whether the timer is currently running.
+    pub fn is_running(&self) -> bool {
+        self.last.is_some()
+    }
+
     pub fn get_stats(&self) -> T::Statistics {
         self.tracker.get_stats(self.last.map(|l| self.source.get_time() - l))
     }

--- a/src/timerset.rs
+++ b/src/timerset.rs
@@ -47,6 +47,11 @@ impl <Key, T, S> TimerSet<Key, T, S> where Key: Eq + Hash + Clone, T: Tracker, S
         self.current = None;
     }
 
+    /// Returns whether the timer is currently running.
+    pub fn is_running(&self) -> bool {
+        self.current.is_some()
+    }
+
     pub fn get_stats(&self, k: Key) -> Option<T::Statistics> {
         let now = match self.current {
             Some((ref current, t)) if *current == k => Some(self.source.get_time() - t),


### PR DESCRIPTION
This is required because code paths may encounter a stop() call before they hit start(). In this case, stop() should be a no-op, but the code panics instead. This API preserves the panic for unintentional reversals, but adds an API to conditionally call stop() in legitimate use cases.

Authored by @ms705